### PR TITLE
Add replay removal job

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -18,7 +18,7 @@ REDIS_PORT=6379
 
 # If disabled, the data gets stored locally
 # Buckets will be created automatically when enabled
-ENABLE_S3=True
+ENABLE_S3=False
 
 # Used for ingame links
 DOMAIN_NAME=localhost

--- a/app/jobs/replays.py
+++ b/app/jobs/replays.py
@@ -1,0 +1,33 @@
+
+from app.common.database import DBScore
+
+import time
+import app
+
+def replays():
+    """Job for automatically removing score replays if they have been beaten"""
+
+    last_id = app.session.database.session.query(DBScore.id) \
+                .order_by(DBScore.id.desc()) \
+                .first()
+
+    last_id = last_id[0] if last_id else 1
+
+    while True:
+        with app.session.database.managed_session() as session:
+            results = session.query(DBScore) \
+                        .filter(DBScore.id > last_id) \
+                        .filter(DBScore.status == 2) \
+                        .order_by(DBScore.id.asc()) \
+                        .all()
+
+            for score in results:
+                app.session.storage.remove_replay(score.id)
+                last_id = score.id
+
+        for _ in range(30):
+            if app.session.jobs._shutdown:
+                exit()
+
+            time.sleep(1)
+

--- a/app/server.py
+++ b/app/server.py
@@ -11,6 +11,7 @@ from .common.cache import status
 from .jobs import (
     rank_indexing,
     activities,
+    replays,
     events,
     pings
 )
@@ -46,6 +47,7 @@ class BanchoFactory(Factory):
 
         app.session.logger.info('Loading jobs...')
         app.session.jobs.submit(pings.ping_job)
+        app.session.jobs.submit(replays.replays)
         app.session.jobs.submit(events.event_listener)
         app.session.jobs.submit(activities.match_activity)
         app.session.jobs.submit(rank_indexing.index_ranks)


### PR DESCRIPTION
When scores haven been overwritten by the user, the old replay should be removed.
I don't know if this "replay removal job" will be enough for it, but it should *technically* work...

Resolves: https://github.com/osuTitanic/deck/issues/42