### PR TITLE
Refactor geolocation & refactor thread handling from thread pools to twisted deferred objects

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -36,7 +36,7 @@ AUTOJOIN_CHANNELS=['#osu', '#announce']
 BANCHO_PORTS=[13380, 13381, 13382, 13383]
 
 # You can change this, depending on how many threads you have
-BANCHO_WORKERS=15
+BANCHO_WORKERS=10
 
 # This will enable maintenance mode. Only admins can connect in this state.
 BANCHO_MAINTENANCE=False

--- a/.env_example
+++ b/.env_example
@@ -35,12 +35,6 @@ AUTOJOIN_CHANNELS=['#osu', '#announce']
 # Usually its port 13382
 BANCHO_PORTS=[13380, 13381, 13382, 13383]
 
-# Amount of threads for handling logins, packets, and database writes
-# Increasing them too much, can cause database issues
-BANCHO_PACKET_WORKERS=10
-BANCHO_LOGIN_WORKERS=5
-BANCHO_DB_WORKERS=2
-
 # This will enable maintenance mode. Only admins can connect in this state.
 BANCHO_MAINTENANCE=False
 

--- a/.env_example
+++ b/.env_example
@@ -35,6 +35,9 @@ AUTOJOIN_CHANNELS=['#osu', '#announce']
 # Usually its port 13382
 BANCHO_PORTS=[13380, 13381, 13382, 13383]
 
+# You can change this, depending on how many threads you have
+BANCHO_WORKERS=15
+
 # This will enable maintenance mode. Only admins can connect in this state.
 BANCHO_MAINTENANCE=False
 

--- a/app/clients/handler.py
+++ b/app/clients/handler.py
@@ -1166,8 +1166,7 @@ def match_complete(player: Player):
     # Players that have been playing this round
     players = [
         slot.player for slot in player.match.slots
-        if slot.status.value & SlotStatus.Complete.value
-        and slot.has_player
+        if slot.completed
     ]
 
     # Wait for score queue to finish processing

--- a/app/clients/handler.py
+++ b/app/clients/handler.py
@@ -1236,7 +1236,7 @@ def match_complete(player: Player):
                         },
                         'place': rank + 1
                     }
-                    for rank, slot in enumerate(slots)
+                    for rank, slot in enumerate(slots) if slot != None
                 ]
             }
         )

--- a/app/clients/handler.py
+++ b/app/clients/handler.py
@@ -762,6 +762,12 @@ def leave_match(player: Player):
         data={'user_id': player.id}
     )
 
+    if (player is player.match.host and player.match.beatmap_id == -1):
+        # Host was choosing beatmap; reset beatmap to previous
+        player.match.beatmap_id = player.match.previous_beatmap_id
+        player.match.beatmap_hash = player.match.previous_beatmap_hash
+        player.match.beatmap_name = player.match.previous_beatmap_name
+
     if all(slot.empty for slot in player.match.slots):
         player.enqueue_match_disband(player.match.id)
 

--- a/app/clients/handler.py
+++ b/app/clients/handler.py
@@ -629,6 +629,7 @@ def create_match(player: Player, bancho_match: bMatch):
     if player.match:
         player.logger.warning('Tried to create match, but was already inside one')
         player.enqueue_matchjoin_fail()
+        player.match.kick_player(player)
         return
 
     match = Match.from_bancho_match(bancho_match, player)
@@ -689,6 +690,7 @@ def join_match(player: Player, match_join: bMatchJoin):
         # Player already joined the match
         player.logger.warning(f'{player.name} tried to join a match, but is already inside one')
         player.enqueue_matchjoin_fail()
+        player.match.kick_player(player)
         return
 
     if player is not match.host:

--- a/app/events.py
+++ b/app/events.py
@@ -52,6 +52,13 @@ def osu_error(user_id: int, error: dict):
         f'{json.dumps(error, indent=4)}'
     )
 
+    if channel := app.session.channels.by_name('#admin'):
+        channel.send_message(
+            app.session.bot_player,
+            f'Client error from "{player.name}". Please check the logs!',
+            ignore_privs=True
+        )
+
     # When a beatmap fails to load inside a match, the player
     # gets forced to the menu screen. In this state, everything
     # is a little buggy, but aborting the match fixes pretty much everything.

--- a/app/events.py
+++ b/app/events.py
@@ -44,5 +44,4 @@ def announcement(message: str):
 @app.session.events.register('shutdown')
 def shutdown():
     """Used to shutdown the event_listener thread"""
-    if app.session.jobs._shutdown:
-        exit()
+    exit()

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -1,7 +1,7 @@
 
+from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import Future
-from concurrent.futures       import ThreadPoolExecutor
-from typing                   import Any, Callable, Tuple
+from typing import Any, Callable, Tuple
 
 from . import events
 from . import pings

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -22,13 +22,12 @@ class Jobs(ThreadPoolExecutor):
         return future
 
     def sleep(self, seconds: float):
-        while seconds > 0:
-            time.sleep(1)
-            seconds -= 1
-
+        for _ in range(seconds):
             if self._shutdown:
                 # Exit thread
                 exit()
+
+            time.sleep(1)
 
     def __future_callback(self, future: Future):
         if e := future.exception():

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -7,6 +7,7 @@ from . import events
 from . import pings
 
 import logging
+import time
 
 class Jobs(ThreadPoolExecutor):
     def __init__(self, max_workers = None, thread_name_prefix: str = "job", initializer = None, initargs: Tuple[Any, ...] = ...) -> None:
@@ -15,5 +16,30 @@ class Jobs(ThreadPoolExecutor):
         self.logger = logging.getLogger('anchor')
 
     def submit(self, fn: Callable, *args, **kwargs) -> Future:
+        future = super().submit(fn, *args, **kwargs)
+        future.add_done_callback(self.__future_callback)
         self.logger.info(f'  - Starting job: "{fn.__name__}"')
-        return super().submit(fn, *args, **kwargs)
+        return future
+
+    def sleep(self, seconds: float):
+        while seconds > 0:
+            time.sleep(1)
+            seconds -= 1
+
+            if self._shutdown:
+                # Exit thread
+                exit()
+
+    def __future_callback(self, future: Future):
+        if e := future.exception():
+            if isinstance(e, SystemExit):
+                return
+
+            self.logger.error(
+                f'Future {future.__repr__()} raised an exception: {e}',
+                exc_info=e
+            )
+
+        self.logger.debug(
+            f'Result for job {future.__repr__()}: {future.result()}'
+        )

--- a/app/jobs/activities.py
+++ b/app/jobs/activities.py
@@ -22,4 +22,4 @@ def match_activity():
                 )
                 match.close()
 
-        time.sleep(5)
+        app.session.jobs.sleep(5)

--- a/app/jobs/replays.py
+++ b/app/jobs/replays.py
@@ -6,6 +6,7 @@ import app
 
 def replays():
     """Job for automatically removing score replays if they have been beaten"""
+    # TODO: Move this somewhere else?
 
     last_id = app.session.database.session.query(DBScore.id) \
                 .order_by(DBScore.id.desc()) \

--- a/app/jobs/replays.py
+++ b/app/jobs/replays.py
@@ -1,7 +1,5 @@
 
 from app.common.database import DBScore
-
-import time
 import app
 
 def replays():
@@ -26,9 +24,4 @@ def replays():
                 app.session.storage.remove_replay(score.id)
                 last_id = score.id
 
-        for _ in range(30):
-            if app.session.jobs._shutdown:
-                exit()
-
-            time.sleep(1)
-
+        app.session.jobs.sleep(30)

--- a/app/objects/client.py
+++ b/app/objects/client.py
@@ -128,14 +128,10 @@ class OsuClient:
         except (ValueError, IndexError):
             pass
 
-        if not (geolocation := app.session.geolocation_cache.get(ip)):
-            geolocation = location.fetch_geolocation(
-                ip=ip,
-                is_local=utils.is_local_ip(ip)
-            )
-
-            # Load ip geolocation from web and store to cache
-            app.session.executor.submit(utils.load_geolocation_web, ip)
+        geolocation = location.fetch_geolocation(
+            ip=ip,
+            is_local=utils.is_local_ip(ip)
+        )
 
         utc_offset = int(
             datetime.now(

--- a/app/objects/multiplayer.py
+++ b/app/objects/multiplayer.py
@@ -69,6 +69,10 @@ class Slot:
     def has_player(self) -> bool:
         return self.player is not None
 
+    @property
+    def completed(self) -> bool:
+        return self.status & SlotStatus.Complete and self.has_player
+
     def copy_from(self, other) -> None:
         self.player = other.player
         self.status = other.status

--- a/app/objects/multiplayer.py
+++ b/app/objects/multiplayer.py
@@ -115,6 +115,10 @@ class Match:
         self.beatmap_name = beatmap_name
         self.beatmap_hash = beatmap_hash
 
+        self.previous_beatmap_id   = beatmap_id
+        self.previous_beatmap_name = beatmap_name
+        self.previous_beatmap_hash = beatmap_hash
+
         self.mods = Mods.NoMod
         self.mode = mode
         self.seed = seed
@@ -306,6 +310,10 @@ class Match:
             # Host is selecting new map
             self.logger.info('Host is selecting map...')
             self.unready_players()
+
+            self.previous_beatmap_id = self.beatmap_id
+            self.previous_beatmap_hash = self.beatmap_hash
+            self.previous_beatmap_name = self.beatmap_name
 
             self.beatmap_id = -1
             self.beatmap_hash = ""

--- a/app/objects/multiplayer.py
+++ b/app/objects/multiplayer.py
@@ -273,6 +273,7 @@ class Match:
         for slot in self.slots:
             if slot.status == expected:
                 slot.status = SlotStatus.NotReady
+                slot.skipped = False
                 slot.loaded = False
 
     def change_settings(self, new_match: bMatch):

--- a/app/objects/multiplayer.py
+++ b/app/objects/multiplayer.py
@@ -444,6 +444,7 @@ class Match:
             return
 
         self.in_progress = True
+        self.score_queue = Queue()
 
         # Execute score queue
         threads.deferToThread(self._process_score_queue) \

--- a/app/objects/multiplayer.py
+++ b/app/objects/multiplayer.py
@@ -207,9 +207,16 @@ class Match:
 
     @property
     def loaded_players(self) -> List[bool]:
-        # Clients in version b323 and below don't have the MATCH_LOAD_COMPLETE packet
-        # so we can just ignore them...
-        return [slot.loaded for slot in self.slots if slot.has_map and slot.player.client.version.date > 323]
+        # Clients in version b323 and below don't have the MATCH_LOAD_COMPLETE
+        # packet so we can just ignore them...
+        return [
+            slot.loaded
+            for slot in self.slots
+            if (
+                slot.status == SlotStatus.Playing and
+                slot.player.client.version.date > 323
+            )
+        ]
 
     def get_slot(self, player: Player) -> Optional[Slot]:
         for slot in self.slots:
@@ -266,6 +273,7 @@ class Match:
         for slot in self.slots:
             if slot.status == expected:
                 slot.status = SlotStatus.NotReady
+                slot.loaded = False
 
     def change_settings(self, new_match: bMatch):
         if self.freemod != new_match.freemod:

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -67,35 +67,6 @@ import utils
 import time
 import app
 
-def login_callback(future: Future):
-    if (e := future.exception()):
-        app.session.logger.error(
-            f'Exception in login thread {future}: {e}',
-            exc_info=e
-        )
-        raise e
-
-    app.session.logger.debug(
-        f'Login Result: {future}'
-    )
-
-def login_thread(func):
-    def wrapper(*args, **kwargs) -> Future:
-        try:
-            f = app.session.login_queue.submit(
-                func,
-                *args,
-                **kwargs
-            )
-            f.add_done_callback(
-                login_callback
-            )
-            return f
-        except RuntimeError:
-            exit()
-
-    return wrapper
-
 class Player(BanchoProtocol):
     def __init__(self, address: IPAddress) -> None:
         self.is_local = utils.is_local_ip(address.host)
@@ -500,7 +471,6 @@ class Player(BanchoProtocol):
 
         self.logger.debug(f'Assigned decoder with version b{version}')
 
-    @login_thread
     def login_received(self, username: str, md5: str, client: OsuClient):
         self.logger = logging.getLogger(f'Player "{username}"')
         self.logger.info(f'Login attempt as "{username}" with {client.version}.')

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -725,6 +725,12 @@ class Player(BanchoProtocol):
             self.logger.warning(f'Could not find a handler function for "{packet}".')
             return
 
+        if packet.name == "MATCH_SCORE_UPDATE":
+            # Threading somehow messes with the packets, so
+            # we just execute it normally for now...
+            handler_function(*[self, args])
+            return
+
         deferred = threads.deferToThread(
             handler_function,
            *[self, args] if args != None else

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -42,7 +42,6 @@ from app.objects import OsuClient, Status
 
 from typing import Optional, Callable, List, Dict, Set
 from datetime import datetime, timedelta
-from concurrent.futures import Future
 from threading import Timer
 from enum import Enum
 from copy import copy

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -725,12 +725,6 @@ class Player(BanchoProtocol):
             self.logger.warning(f'Could not find a handler function for "{packet}".')
             return
 
-        if packet.name == "MATCH_SCORE_UPDATE":
-            # Threading somehow messes with the packets, so
-            # we just execute it normally for now...
-            handler_function(*[self, args])
-            return
-
         deferred = threads.deferToThread(
             handler_function,
            *[self, args] if args != None else

--- a/app/protocol.py
+++ b/app/protocol.py
@@ -2,6 +2,7 @@
 from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.error import ConnectionDone
 from twisted.internet.protocol import Protocol
+from twisted.internet import threads, reactor
 from twisted.python.failure import Failure
 
 from typing import Union, Optional
@@ -86,11 +87,15 @@ class BanchoProtocol(Protocol):
             self.dataReceived = self.packetDataReceived
 
             # Handle login
-            self.login_received(
+            deferred = threads.deferToThread(
+                self.login_received,
                 username.decode(),
                 password.decode(),
                 self.client
             )
+
+            deferred.addErrback(self.login_callback)
+            deferred.addTimeout(15, reactor)
         except Exception as e:
             self.logger.error(
                 f'Error on login: {e}',
@@ -200,11 +205,17 @@ class BanchoProtocol(Protocol):
                 exc_info=e
             )
 
-    def send_error(self, reason = -5, message = ""):
+    def login_callback(self, error: Failure):
+        self.logger.error(
+            f'Exception while logging in: "{error.getErrorMessage()}"',
+            exc_info=error.value
+        )
+
+    def login_received(self, username: str, md5: str, client: OsuClient):
         ...
 
     def packet_received(self, packet_id: int, stream: StreamIn):
         ...
 
-    def login_received(self, username: str, md5: str, client: OsuClient):
+    def send_error(self, reason = -5, message = ""):
         ...

--- a/app/protocol.py
+++ b/app/protocol.py
@@ -198,7 +198,7 @@ class BanchoProtocol(Protocol):
 
             stream.write(data)
 
-            self.enqueue(stream.get())
+            reactor.callFromThread(self.enqueue, stream.get())
         except Exception as e:
             self.logger.error(
                 f'Could not send packet "{packet.name}": {e}',

--- a/app/server.py
+++ b/app/server.py
@@ -65,7 +65,6 @@ class BanchoFactory(Factory):
 
         app.session.events.submit('shutdown')
         app.session.jobs.shutdown(cancel_futures=True, wait=False)
-        app.session.pool.stop()
 
     def buildProtocol(self, addr: IAddress) -> Optional[Protocol]:
         client = self.protocol(addr)

--- a/app/server.py
+++ b/app/server.py
@@ -65,6 +65,7 @@ class BanchoFactory(Factory):
 
         app.session.events.submit('shutdown')
         app.session.jobs.shutdown(cancel_futures=True, wait=False)
+        app.session.pool.stop()
 
     def buildProtocol(self, addr: IAddress) -> Optional[Protocol]:
         client = self.protocol(addr)

--- a/app/server.py
+++ b/app/server.py
@@ -64,7 +64,6 @@ class BanchoFactory(Factory):
             status.delete(player.id)
 
         app.session.events.submit('shutdown')
-        app.session.executor.shutdown(wait=True)
         app.session.jobs.shutdown(cancel_futures=True, wait=False)
 
     def buildProtocol(self, addr: IAddress) -> Optional[Protocol]:

--- a/app/server.py
+++ b/app/server.py
@@ -66,8 +66,6 @@ class BanchoFactory(Factory):
         app.session.events.submit('shutdown')
         app.session.executor.shutdown(wait=True)
         app.session.jobs.shutdown(cancel_futures=True, wait=False)
-        app.session.packet_executor.shutdown(cancel_futures=True, wait=False)
-        app.session.login_queue.shutdown(cancel_futures=True, wait=False)
 
     def buildProtocol(self, addr: IAddress) -> Optional[Protocol]:
         client = self.protocol(addr)

--- a/app/server.py
+++ b/app/server.py
@@ -16,7 +16,9 @@ from .jobs import (
     pings
 )
 
+import signal
 import app
+import os
 
 class BanchoFactory(Factory):
     protocol = Player
@@ -65,6 +67,15 @@ class BanchoFactory(Factory):
 
         app.session.events.submit('shutdown')
         app.session.jobs.shutdown(cancel_futures=True, wait=False)
+
+        def force_exit(signal, frame):
+            app.session.logger.warning("Force exiting...")
+            os._exit(0)
+
+        signal.signal(signal.SIGINT, force_exit)
+
+        for thread in app.session.pool.threads:
+            app.session.logger.warning(f'Shutting down: "{thread.name}"')
 
     def buildProtocol(self, addr: IAddress) -> Optional[Protocol]:
         client = self.protocol(addr)

--- a/app/session.py
+++ b/app/session.py
@@ -42,12 +42,6 @@ requests.headers = {
 
 handlers: Dict[DefaultResponsePacket, Callable] = {}
 
-# This is to prevent database overload when too many users log in at the same time
-login_queue = ThreadPoolExecutor(max_workers=config.LOGIN_WORKERS)
-
-# Used to run most of the packets in threads, except for things like messages
-packet_executor = ThreadPoolExecutor(max_workers=config.PACKET_WORKERS)
-
 # This is mostly used for database writes like messages, user activity and so on...
 executor = ThreadPoolExecutor(max_workers=config.DB_WORKERS)
 

--- a/app/session.py
+++ b/app/session.py
@@ -6,7 +6,6 @@ from .common.database import Postgres
 from .common.storage import Storage
 from .jobs import Jobs
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Dict
 from requests import Session
 from redis import Redis
@@ -40,9 +39,6 @@ requests.headers = {
 }
 
 handlers: Dict[DefaultResponsePacket, Callable] = {}
-
-# This is mostly used for database writes like messages, user activity and so on...
-executor = ThreadPoolExecutor(max_workers=config.DB_WORKERS)
 
 channels = Channels()
 storage = Storage()

--- a/app/session.py
+++ b/app/session.py
@@ -6,6 +6,9 @@ from .common.database import Postgres
 from .common.storage import Storage
 from .jobs import Jobs
 
+from twisted.python.threadpool import ThreadPool
+from twisted.internet import reactor
+
 from typing import Callable, Dict
 from requests import Session
 from redis import Redis
@@ -39,6 +42,9 @@ requests.headers = {
 }
 
 handlers: Dict[DefaultResponsePacket, Callable] = {}
+
+pool: ThreadPool = reactor.getThreadPool()
+pool.adjustPoolsize(5, config.BANCHO_WORKERS)
 
 channels = Channels()
 storage = Storage()

--- a/app/session.py
+++ b/app/session.py
@@ -32,7 +32,6 @@ events = EventQueue(
 )
 
 logger = logging.getLogger('bancho')
-geolocation_cache = {}
 bot_player = None
 
 requests = Session()

--- a/config.py
+++ b/config.py
@@ -23,10 +23,6 @@ AUTOJOIN_CHANNELS = eval(os.environ.get('AUTOJOIN_CHANNELS', "['#osu', '#announc
 
 PORTS = eval(os.environ.get('BANCHO_PORTS', '[13381, 13382, 13383]'))
 
-PACKET_WORKERS = int(os.environ.get('BANCHO_PACKET_WORKERS', 10))
-LOGIN_WORKERS = int(os.environ.get('BANCHO_LOGIN_WORKERS', 5))
-DB_WORKERS = int(os.environ.get('BANCHO_DB_WORKERS', 2))
-
 DOMAIN_NAME = os.environ.get('DOMAIN_NAME')
 
 MENUICON_IMAGE = os.environ.get('MENUICON_IMAGE')

--- a/config.py
+++ b/config.py
@@ -21,6 +21,8 @@ REDIS_PORT = int(os.environ.get('REDIS_PORT', 6379))
 
 AUTOJOIN_CHANNELS = eval(os.environ.get('AUTOJOIN_CHANNELS', "['#osu', '#announce']"))
 
+BANCHO_WORKERS = int(os.environ.get('BANCHO_WORKERS', 15))
+
 PORTS = eval(os.environ.get('BANCHO_PORTS', '[13381, 13382, 13383]'))
 
 DOMAIN_NAME = os.environ.get('DOMAIN_NAME')

--- a/utils.py
+++ b/utils.py
@@ -68,28 +68,3 @@ def is_local_ip(ip: str) -> bool:
 
     return False
 
-def update_player_location(geolocation: location.Geolocation) -> None:
-    """Will try to update the player's geolocation data"""
-    app.session.logger.debug('Updating player geolocation...')
-
-    for retry in range(5):
-        for player in app.session.players:
-            if player.address.host != geolocation.ip:
-                continue
-
-            player.client.ip = geolocation
-            app.session.logger.info(f'Updated geolocation of {player} ({geolocation.ip})')
-            app.session.players.send_player(player)
-            return
-
-        app.session.logger.debug('Failed to update player geolocation. Retrying...')
-        time.sleep(1)
-
-def load_geolocation_web(address: str) -> None:
-    """Fetch geolocation data from web and store it to cache"""
-    if not (result := location.fetch_web(address, is_local_ip(address))):
-        return
-
-    app.session.geolocation_cache[address] = result
-
-    update_player_location(result)

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 
+from twisted.python.failure import Failure
 from app.common.constants import ANCHOR_ASCII_ART
 from app.common.database import DBScore
 from app.common.helpers import location
@@ -68,3 +69,8 @@ def is_local_ip(ip: str) -> bool:
 
     return False
 
+def thread_callback(error: Failure):
+    app.session.logger.error(
+        f'Failed to execute thread: "{error.getErrorMessage()}"',
+        exc_info=error.value
+    )


### PR DESCRIPTION
I've noticed a feature in the twisted library called "[Deferred](https://docs.twisted.org/en/twisted-18.9.0/core/howto/defer.html)", which handles pretty much the whole callback sequence of the reactor. This sounds way harder than it actually is, and it is definitely better than my current thread pool solution.
This still needs to be tested, since threaded multiplayer packets sometimes messed with the clients for some reason.
I would also like to stress-test this some day...