### PR TITLE
Migrate to new client manifest & fix client hash verification

### DIFF
--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -550,6 +550,7 @@ class Player:
 
             if config.MAINTENANCE:
                 if not self.is_staff:
+                    # Bancho is in maintenance mode
                     self.logger.warning('Login Failed: Maintenance')
                     self.login_failed(
                         LoginError.ServerError,
@@ -564,8 +565,11 @@ class Player:
                 if not clients.is_valid_client_hash(self.client.hash.md5):
                     self.logger.warning('Login Failed: Unsupported client')
                     self.login_failed(
-                        LoginError.Authentication,
+                        LoginError.UpdateNeeded,
                         message=strings.UNSUPPORTED_HASH
+                    )
+                    officer.call(
+                        f'Player tried to log in with an unsupported version: {self.client.version} ({self.client.hash.md5})'
                     )
                     self.close_connection()
                     return

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -41,6 +41,7 @@ from app.common.database.repositories import (
 from app.common.streams import StreamIn, StreamOut
 from app.common.database import DBUser, DBStats
 from app.objects import OsuClient, Status
+from app.common.helpers import clients
 from app.common import mail
 
 from typing import Callable, List, Dict, Set
@@ -559,9 +560,8 @@ class Player:
                 self.enqueue_announcement(strings.MAINTENANCE_MODE_ADMIN)
 
             if not config.DISABLE_CLIENT_VERIFICATION and not self.is_staff:
-                # Check client's executable hash
-                # (Admins can bypass this check)
-                if not utils.valid_client_hash(self.client.hash.md5):
+                # Check client's executable hash (Admins can bypass this check)
+                if not clients.is_valid_client_hash(self.client.hash.md5):
                     self.logger.warning('Login Failed: Unsupported client')
                     self.login_failed(
                         LoginError.Authentication,

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -38,10 +38,10 @@ from app.common.database.repositories import (
     stats
 )
 
+from app.common.helpers import clients as client_utils
 from app.common.streams import StreamIn, StreamOut
 from app.common.database import DBUser, DBStats
 from app.objects import OsuClient, Status
-from app.common.helpers import clients
 from app.common import mail
 
 from typing import Callable, List, Dict, Set
@@ -562,7 +562,7 @@ class Player:
 
             if not config.DISABLE_CLIENT_VERIFICATION and not self.is_staff:
                 # Check client's executable hash (Admins can bypass this check)
-                if not clients.is_valid_client_hash(self.client.hash.md5):
+                if not client_utils.is_valid_client_hash(self.client.hash.md5):
                     self.logger.warning('Login Failed: Unsupported client')
                     self.login_failed(
                         LoginError.UpdateNeeded,

--- a/app/session.py
+++ b/app/session.py
@@ -9,7 +9,7 @@ from .jobs import Jobs
 from twisted.python.threadpool import ThreadPool
 from twisted.internet import reactor
 
-from typing import Callable, Optional, Dict
+from typing import Callable, Dict
 from requests import Session
 from redis import Redis
 
@@ -51,5 +51,3 @@ storage = Storage()
 players = Players()
 matches = Matches()
 jobs = Jobs()
-
-client_manifest: Optional[dict] = None

--- a/main.py
+++ b/main.py
@@ -67,6 +67,11 @@ def setup():
     # Reset usercount
     usercount.set(0)
 
+    # Reset player statuses
+    for key in status.get_all():
+        player_id = key.split(':')[-1]
+        status.delete(player_id)
+
 def shutdown():
     # Reset usercount
     usercount.set(0)

--- a/utils.py
+++ b/utils.py
@@ -10,22 +10,3 @@ def thread_callback(error: Failure):
         f'Failed to execute thread: {error.__str__()} ({error.getErrorMessage()})',
         exc_info=error.value
     )
-
-def valid_client_hash(hash: str) -> bool:
-    try:
-        if not (manifest := app.session.client_manifest):
-            response = app.session.requests.get(f'http://osu.{config.DOMAIN_NAME}/clients/manifest.json')
-
-            if not response.ok:
-                return True
-
-            app.session.client_manifest = response.json()
-            return valid_client_hash(hash)
-
-    except ConnectionError:
-        app.session.logger.warning(
-            f'Failed to get client manifest from: "http://osu.{config.DOMAIN_NAME}/clients/manifest.json"'
-        )
-        return True
-
-    return hash in manifest['hashes']


### PR DESCRIPTION
This is fixing a longstanding bug that I didn't notice for multiple weeks: Client hash verification. This was really just me forgetting to test the feature, and also forgetting to enable it in the config... Welp... now it's fixed.
Other than that I fixed a bug where the player status would remain existent when it got deleted, and I also migrated to the new client manifest (https://github.com/osuTitanic/deck/pull/205).