### PR TITLE
Refactor channel component

### DIFF
--- a/app/banchobot.py
+++ b/app/banchobot.py
@@ -132,7 +132,7 @@ class BanchoBot(Player):
         target_name = (
             context.target.name
             if type(context.target) != Channel
-            else context.target.display_name
+            else context.target.display_name(context.player)
         )
 
         # Send to sender only

--- a/app/banchobot.py
+++ b/app/banchobot.py
@@ -132,7 +132,7 @@ class BanchoBot(Player):
         target_name = (
             context.target.name
             if type(context.target) != Channel
-            else context.target.display_name(context.player)
+            else context.target.display_name
         )
 
         # Send to sender only

--- a/app/clients/handler.py
+++ b/app/clients/handler.py
@@ -2,10 +2,10 @@
 from . import DefaultResponsePacket as ResponsePacket
 from . import DefaultRequestPacket as RequestPacket
 
+from ..objects.channel import Channel, MultiplayerChannel
 from ..common.database.objects import DBBeatmap, DBScore
 from ..common.database.repositories import wrapper
 from ..objects.multiplayer import Match
-from ..objects.channel import Channel
 from ..objects.player import Player
 from ..common import officer
 from .. import session
@@ -629,17 +629,8 @@ def create_match(player: Player, bancho_match: bMatch):
     for index, slot in enumerate(bancho_match.slots):
         match.slots[index].status = slot.status
 
-    session.channels.add(
-        c := Channel(
-            name=f'#multi_{match.id}',
-            topic=match.name,
-            owner=match.host.name,
-            read_perms=1,
-            write_perms=1,
-            public=False
-        )
-    )
-    match.chat = c
+    match.chat = MultiplayerChannel(match)
+    session.channels.add(match.chat)
 
     match.db_match = matches.create(
         match.name,

--- a/app/objects/__init__.py
+++ b/app/objects/__init__.py
@@ -1,5 +1,3 @@
 
 from .client import OsuClient
 from .status import Status
-
-from . import collections

--- a/app/objects/channel.py
+++ b/app/objects/channel.py
@@ -133,7 +133,7 @@ class Channel:
                 )
 
     def broadcast_message(self, message: bMessage, users: List["Player"]) -> None:
-        self.logger.info(f'[{message.sender}]: {message}')
+        self.logger.info(f'[{message.sender}]: {message.content}')
 
         if self.ignore_display_name:
             for user in users:

--- a/app/objects/channel.py
+++ b/app/objects/channel.py
@@ -1,5 +1,5 @@
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Set
 
 if TYPE_CHECKING:
     from app.objects.player import Player
@@ -8,7 +8,7 @@ from app.common.database.repositories import messages
 from app.common.constants.strings import BAD_WORDS
 from app.common.objects import bMessage, bChannel
 from app.common.constants import Permissions
-from app.objects import collections
+from app.objects.locks import LockedSet
 from app.common import officer
 
 import logging
@@ -35,7 +35,7 @@ class Channel:
         self.public = public
 
         self.logger = logging.getLogger(self.name)
-        self.users = collections.Players()
+        self.users: LockedSet["Player"] = LockedSet()
 
     def __repr__(self) -> str:
         return f'<{self.name} - {self.topic}>'

--- a/app/objects/channel.py
+++ b/app/objects/channel.py
@@ -149,8 +149,7 @@ class Channel:
         sender: "Player",
         message: str,
         ignore_privileges=False,
-        ignore_commands=False,
-        exclude_sender=True
+        ignore_commands=False
     ) -> None:
         if sender not in self.users and not sender.is_bot:
             # Player did not join this channel
@@ -200,15 +199,12 @@ class Channel:
             officer.call(f'Message: {message}')
             return
 
-        users = self.users
-
-        if exclude_sender:
-            # Filter out sender, if needed
-            users = {user for user in self.users if user != sender}
-
         # Limit message size to 512 characters
         if len(message) > 512:
             message = message[:497] + '... (truncated)'
+
+        # Filter out sender
+        users = {user for user in self.users if user != sender}
 
         self.broadcast_message(
             bMessage(

--- a/app/objects/channel.py
+++ b/app/objects/channel.py
@@ -229,6 +229,7 @@ class SpectatorChannel(Channel):
             write_perms=1,
             public=False
         )
+        self.player = player
 
     @property
     def display_name(self) -> str:
@@ -244,6 +245,7 @@ class MultiplayerChannel(Channel):
             write_perms=1,
             public=False
         )
+        self.match = match
 
     @property
     def display_name(self) -> str:

--- a/app/objects/collections.py
+++ b/app/objects/collections.py
@@ -188,7 +188,7 @@ class Channels(Dict[str, Channel]):
             return
 
         for p in c.users:
-            p.revoke_channel(c.display_name)
+            p.revoke_channel(c.display_name(p))
 
         if c.name in self:
             del self[c.name]

--- a/app/objects/collections.py
+++ b/app/objects/collections.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 from enum import Enum
 from typing import (
-    Iterable,
     Iterator,
     Tuple,
     Dict,

--- a/app/objects/collections.py
+++ b/app/objects/collections.py
@@ -187,7 +187,7 @@ class Channels(Dict[str, Channel]):
             return
 
         for p in c.users:
-            p.revoke_channel(c.display_name(p))
+            p.revoke_channel(c.display_name)
 
         if c.name in self:
             del self[c.name]

--- a/app/objects/locks.py
+++ b/app/objects/locks.py
@@ -77,10 +77,13 @@ class LockedSet(Set[T]):
         with self.lock.write_context():
             self.set.add(item)
 
-    def remove(self, item: T) -> None:
-        with self.lock.write_context():
-            self.set.remove(item)
-
     def update(self, *args, **kwargs) -> None:
         with self.lock.write_context():
             self.set.update(*args, **kwargs)
+
+    def remove(self, item: T) -> None:
+        with self.lock.write_context():
+            try:
+                self.set.remove(item)
+            except KeyError:
+                pass


### PR DESCRIPTION
To make the match referee feature possible in bancho, I had to change the way of how channels work. My goal is that match refs will have multiple `#multi_<id>` channels they can write in, but right now all channels starting with `#multi` will be automatically renamed to `#multiplayer`.
The fix for it was to introduce a custom flag for channels, that bypasses the `#multiplayer` renaming for channel owners. I still have to figure out if that will work with multiple referees, but it's a start.
Another small change is the usage of `set` for channel players, instead of using another player collection.